### PR TITLE
Add comma in `config.py.example`

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -23,6 +23,6 @@ arguments = {
     'balance_tel_number7' : '*100#',  # balance number for line 7
     'balance_tel_number8' : '*100#',  # balance number for line 8
     'our_gsm_gateway_ip' : '192.168.0.4',
-    'zabbix_sender_path' : '/usr/bin/zabbix_sender'
+    'zabbix_sender_path' : '/usr/bin/zabbix_sender',
     'ussdports' : '1,2,3,4'
     }


### PR DESCRIPTION
Fixed it
![image](https://user-images.githubusercontent.com/41833771/130771084-0c76e78c-a3c3-4d06-8ddd-5233c34b2ff5.png)
